### PR TITLE
Allow multiblocks to share (most) functional parts

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/IMultiblockPart.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/IMultiblockPart.java
@@ -2,10 +2,21 @@ package gregtech.api.metatileentity.multiblock;
 
 public interface IMultiblockPart {
 
+    /**
+     * @return {@code true} if this part is registered with at least one multiblock controller,
+     * {@code false} otherwise.
+     */
     boolean isAttachedToMultiBlock();
 
     void addToMultiBlock(MultiblockControllerBase controllerBase);
 
     void removeFromMultiBlock(MultiblockControllerBase controllerBase);
 
+    /**
+     * @return {@code true} if this part can be used by multiple multiblock controllers simultaneously,
+     * {@code false} otherwise.
+     */
+    default boolean canPartShare() {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -167,10 +167,8 @@ public abstract class MultiblockControllerBase extends MetaTileEntity {
             ArrayList<IMultiblockPart> parts = new ArrayList<>(rawPartsSet);
             parts.sort(Comparator.comparing(it -> ((MetaTileEntity) it).getPos().hashCode()));
             for (IMultiblockPart part : parts) {
-                if (part.isAttachedToMultiBlock()) {
-                    //disallow sharing of multiblock parts
-                    //if part is already attached to another multiblock,
-                    //stop here without attempting to register abilities
+                // do not form if part is in use and not shareable
+                if (part.isAttachedToMultiBlock() && !part.canPartShare()) {
                     return;
                 }
             }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityEnergyHatch.java
@@ -84,5 +84,12 @@ public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart impl
             tooltip.add(I18n.format("gregtech.universal.tooltip.amperage_in_till", energyContainer.getInputAmperage()));
         }
         tooltip.add(I18n.format("gregtech.universal.tooltip.energy_storage_capacity", energyContainer.getEnergyCapacity()));
+        super.addInformation(stack, player, tooltip, advanced);
+    }
+
+    @Override
+    public boolean canPartShare() {
+        // Energy hatches are NOT shareable, at least for now. Need to add functionality first, otherwise it'd be weird.
+        return false;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityFluidHatch.java
@@ -146,5 +146,11 @@ public class MetaTileEntityFluidHatch extends MetaTileEntityMultiblockNotifiable
     @Override
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("gregtech.universal.tooltip.fluid_storage_capacity", getInventorySize()));
+        super.addInformation(stack, player, tooltip, advanced);
+    }
+
+    @Override
+    public boolean canPartShare() {
+        return true;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityItemBus.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityItemBus.java
@@ -113,5 +113,11 @@ public class MetaTileEntityItemBus extends MetaTileEntityMultiblockNotifiablePar
     @Override
     public void addInformation(ItemStack stack, @Nullable World player, List<String> tooltip, boolean advanced) {
         tooltip.add(I18n.format("gregtech.universal.tooltip.item_storage_capacity", getInventorySize()));
+        super.addInformation(stack, player, tooltip, advanced);
+    }
+
+    @Override
+    public boolean canPartShare() {
+        return true;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -88,8 +88,14 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
 	@Override
 	public ICubeRenderer getBaseTexture() {
 		MultiblockControllerBase controller = getController();
-		int tier = getTier() == 2 ? GTValues.HV : GTValues.IV;
-		return controller == null ? Textures.VOLTAGE_CASINGS[tier] : controller.getBaseTexture(this);
+		if(controller != null)
+			return this.partTexture = controller.getBaseTexture(this);
+		else if(this.partTexture != null)
+			return partTexture;
+		else {
+			int tier = getTier() == 2 ? GTValues.HV : GTValues.IV;
+			return Textures.VOLTAGE_CASINGS[tier];
+		}
 	}
 
 	@Override

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMultiFluidHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMultiFluidHatch.java
@@ -138,5 +138,11 @@ public class MetaTileEntityMultiFluidHatch extends MetaTileEntityMultiblockNotif
 			                        ? "gregtech.machine.fluid_hatch.export.tooltip"
 			                        : "gregtech.machine.fluid_hatch.import.tooltip"));
 		tooltip.add(I18n.format("gregtech.machine.fluid_multi_hatch.capacity", 16000, getTier() * getTier()));
+		super.addInformation(stack, player, tooltip, advanced);
+	}
+
+	@Override
+	public boolean canPartShare() {
+		return true;
 	}
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3030,3 +3030,5 @@ gregtech.command.util.hand.not_a_player=This command is only usable by a player.
 gregtech.command.util.hand.no_item=You must hold something in mainhand before executing this command.
 
 gregtech.universal.clear_nbt_recipe.tooltip=§cThis will destroy all contents!
+gregtech.sharing.enabled=Sharing between Multiblocks: §aEnabled
+gregtech.sharing.disabled=Sharing between Multiblocks: §4Disabled

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -2906,6 +2906,9 @@ gregtech.command.util.hand.meta_item=Название мета-предмета:
 gregtech.command.util.hand.not_a_player=Эта команда может использоваться только игроком.
 gregtech.command.util.hand.no_item=Перед выполнением этой команды, вы должны держать что-то в основной руке.
 
+gregtech.sharing.enabled=Совместное использование между структурами: §aВключено
+gregtech.sharing.disabled=Совместное использование между структурами: §4Выключено
+
 # Fixes
 fluid.tile.water=Вода
 fluid.tile.lava=Лава

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -2884,3 +2884,6 @@ gregtech.command.util.hand.tool_stats=工具状态类: %s
 gregtech.command.util.hand.meta_item=元物品名字: %s
 gregtech.command.util.hand.not_a_player=这条指令只能由玩家使用。
 gregtech.command.util.hand.no_item=必须在主手持握物品时执行这条指令。
+
+gregtech.sharing.enabled=多方块结构共享：§a允许
+gregtech.sharing.disabled=多方块结构共享：§4禁止


### PR DESCRIPTION
- Multiblocks will now form with shareable parts in overlapping positions between controllers.
- Multiblock controllers will consider the contents of these shared parts for recipe lookups.
- Rotor Holders, Coke Oven Hatches, and Energy Hatches are not shareable.
- Buses/Hatches indicate in their tooltip if sharing is permitted.
- Multiblock parts from addon mods will default to not shareable, and will only indicate if they can be shared in their tooltip if they don't override the superclass implementation.
  - The only currently known addon mod at this time is [Shadows of Greg](https://github.com/Shadows-of-Fire/Shadows-of-Greg) which we maintain and will be updated accordingly.
- Energy hatches may become shareable at a later date. Functional changes would be necessary to make them behave not janky when shared. Currently, all attached machines would assume they can use all available voltage which makes it easy to accidentally overclock, resulting in all shared machines running out of power.

Attributions:

  - Adapted from "Spicy Jar" code by Serenibyss

  - Translation keys from GTCEu, from their respective authors:
     - MCTian-mi (zh_cn.lang)
     - Co-authors of https://github.com/GregTechCEu/GregTech/pull/1029 (ru_ru.lang)