### PR TITLE
Multiblock regression and bug fixes, new Jammed state

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -186,7 +186,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
         IMultipleTankHandler importFluids = getInputTank();
 
         // see if the last recipe we used still works
-        if (this.previousRecipe != null && this.previousRecipe.matches(false, importInventory, importFluids))
+        if (checkPreviousRecipe())
             currentRecipe = this.previousRecipe;
         // If there is no active recipe, then we need to find one.
         else {
@@ -201,11 +201,17 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
         // proceed if we have a usable recipe.
         if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe))
             setupRecipe(currentRecipe);
+
         // Inputs have been inspected.
         metaTileEntity.getNotifiedItemInputList().clear();
         metaTileEntity.getNotifiedFluidInputList().clear();
     }
 
+    protected boolean checkPreviousRecipe() {
+        if(this.previousRecipe == null) return false;
+        if(this.previousRecipe.getEUt() > this.getMaxVoltage()) return false;
+        return this.previousRecipe.matches(false, getInputInventory(), getInputTank());
+    }
 
     protected int getMinTankCapacity(IMultipleTankHandler tanks) {
         if(tanks.getTanks() == 0) {

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -28,14 +28,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
      * Used to reset cached values in the Recipe Logic on structure deform
      */
     public void invalidate() {
-        previousRecipe = null;
-        progressTime = 0;
-        maxProgressTime = 0;
-        recipeEUt = 0;
-        fluidOutputs = null;
-        itemOutputs = null;
-        isOutputsFull = false;
-        setActive(false); // this marks dirty for us
+        // this space intentionally left black
     }
 
     public IEnergyContainer getEnergyContainer() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -132,9 +132,10 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 
-            if (!recipeMapWorkable.isWorkingEnabled()) {
+            if(recipeMapWorkable.isJammed()) {
+                textList.add(new TextComponentTranslation("gregtech.multiblock.jammed"));
+            } else if (!recipeMapWorkable.isWorkingEnabled()) {
                 textList.add(new TextComponentTranslation("gregtech.multiblock.work_paused"));
-
             } else if (recipeMapWorkable.isActive()) {
                 textList.add(new TextComponentTranslation("gregtech.multiblock.running"));
                 int currentProgress = (int) (recipeMapWorkable.getProgressPercent() * 100);

--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -10,6 +10,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -332,6 +332,17 @@ public class Recipe {
         return hasValidInputs;
     }
 
+    /**
+     * Retrieve a property or fallback value from the property store
+     * @param property the desired property
+     * @param defaultValue fallback value
+     * @param <T> type of the property
+     * @return the requested property's value, or the fallback value if a value isn't available.
+     */
+    public <T> T getProperty(RecipeProperty<T> property, T defaultValue) {
+        return recipePropertyStorage.getRecipePropertyValue(property, defaultValue);
+    }
+
     //region RecipeProperties
 
     /**

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -11,6 +11,7 @@ import gregtech.api.multiblock.FactoryBlockPattern;
 import gregtech.api.multiblock.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.recipeproperties.*;
 import gregtech.api.render.ICubeRenderer;
 import gregtech.api.render.OrientedOverlayRenderer;
 import gregtech.api.render.Textures;
@@ -68,8 +69,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
 
     @Override
     public boolean checkRecipe(Recipe recipe, boolean consumeIfSuccess) {
-        int recipeRequiredTemp = recipe.getIntegerProperty("blast_furnace_temperature");
-        return this.blastFurnaceTemperature >= recipeRequiredTemp;
+        return this.blastFurnaceTemperature >= recipe.getProperty(BlastTemperatureProperty.getInstance(),0);
     }
 
     public static Predicate<BlockWorldState> heatingCoilPredicate() {

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2962,7 +2962,7 @@ gregtech.fluid_pipe.throughput=Transfer: §e%,d mb/t
 gregtech.fluid_pipe.max_temperature=Max Temperature: §c%,dK
 gregtech.fluid_pipe.non_gas_proof=Can't transfer gases.
 
-gregtech.multiblock.jammed=Unable to complete the recipe with the current configuration.
+gregtech.multiblock.jammed=§cUnable to complete the recipe with the current configuration.
 gregtech.multiblock.work_paused=Work Paused.
 gregtech.multiblock.running=Running perfectly.
 gregtech.multiblock.idling=Idling.

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -2962,6 +2962,7 @@ gregtech.fluid_pipe.throughput=Transfer: §e%,d mb/t
 gregtech.fluid_pipe.max_temperature=Max Temperature: §c%,dK
 gregtech.fluid_pipe.non_gas_proof=Can't transfer gases.
 
+gregtech.multiblock.jammed=Unable to complete the recipe with the current configuration.
 gregtech.multiblock.work_paused=Work Paused.
 gregtech.multiblock.running=Running perfectly.
 gregtech.multiblock.idling=Idling.

--- a/src/main/resources/assets/gregtech/lang/ru_ru.lang
+++ b/src/main/resources/assets/gregtech/lang/ru_ru.lang
@@ -2859,6 +2859,7 @@ gregtech.fluid_pipe.throughput=Пропускная способность: §e%
 gregtech.fluid_pipe.max_temperature=Максимальная температура: §c%dK
 gregtech.fluid_pipe.non_gas_proof=Не может переносить газы.
 
+gregtech.multiblock.jammed=§cНевозможно завершить рецепт с текущей конфигурацией (машины).
 gregtech.multiblock.work_paused=Работа приостановлена.
 gregtech.multiblock.running=Работает отлично.
 gregtech.multiblock.idling=Холостой ход.

--- a/src/main/resources/assets/gregtech/lang/zh_cn.lang
+++ b/src/main/resources/assets/gregtech/lang/zh_cn.lang
@@ -2838,6 +2838,7 @@ gregtech.fluid_pipe.throughput=传输速率: §e%d 升/刻
 gregtech.fluid_pipe.max_temperature=温度上限: §c%d K
 gregtech.fluid_pipe.non_gas_proof=不能传输气体.
 
+gregtech.multiblock.jammed=§c当前（机器）配置无法完成配方。
 gregtech.multiblock.work_paused=暂停.
 gregtech.multiblock.running=运行正常.
 gregtech.multiblock.idling=待机.


### PR DESCRIPTION
### Regression
After merging #2, a regression in behavior occurred where structures would void crafts when broken unlike before where the craft would only void if the controller was broken. This feature branch restores the prior behavior.

### Voiding Bug
While working on it I discovered a related issue where multiblocks were recording all possible recipe outputs rather than truncated outputs determined during recipe setup, and if there was insufficient space to merge all outputs then _all_ outputs would silently void instead of the excess outputs. This has been corrected.

### Jammed State
As a contingency against undefined behavior when a machine is broken and reformed with a configuration that cannot handle the running recipe, that machine will become Jammed. In this state, recipe progress will be frozen, no additional power will be drawn, the multiblock controller's GUI will indicate the machine is Jammed, and the craft will not progress or complete until the player rectifies the configuration issue.

For example, if recipe outputs are computed with an LV output bus resulting in more than one output, then the structure is broken and the bus is replaced with a ULV bus, the machine would Jam until the structure is rebuilt with enough output space for all outputs.

The Jammed state logic also calls `RecipeMapMultiblockController::checkRecipe()` to allow for polymorphic behaviors unique to specific multiblocks. For example an EBF will become Jammed if the coils were replaced with different ones of an insufficient tier for the recipe (e.g replacing Kanthal coils with Cupronickel).

### Shared Parts Considerations
Shared multiblock parts risk a race condition where another multiblock completes its craft, obstructing the outputs for other machines. If there is insufficient space for all outputs when a machine tries to complete the craft, the merge will fail and all outputs of that type would be voided.

To prevent this from happening, `MultiblockRecipeLogic` will verify all recipe conditions are satisfied before allowing the craft to complete. If validation fails, the machine will become Jammed. Validation will be performed each time the structure is invalidated and reformed, or the outputs notify the controller of state change. Once validation succeeds, the machine will stop being Jammed and the recipe will complete.