### PR TITLE
Fix a long-standing bug in GTCE's chanced outputs computation

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -318,8 +318,8 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
         setMaxProgress(resultOverclock[1]);
         this.recipeEUt = resultOverclock[0];
         this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs());
-        int tier = getMachineTierForRecipe(recipe);
-        this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(), random, tier));
+        int overclocks = getMachineTierForRecipe(recipe) - recipe.getBaseTier();
+        this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(), random, overclocks));
         if (this.wasActiveAndNeedsUpdate) {
             this.wasActiveAndNeedsUpdate = false;
         } else {

--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -1,6 +1,7 @@
 package gregtech.api.recipes;
 
 import com.google.common.collect.ImmutableList;
+import gregtech.api.GTValues;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
 import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
@@ -13,6 +14,9 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static java.util.Arrays.binarySearch;
+import static net.minecraft.util.math.MathHelper.abs;
 
 /**
  * Class that represent machine recipe.<p>
@@ -52,6 +56,11 @@ public class Recipe {
      * if > 0 means EU/t consumed, if < 0 - produced
      */
     private final int EUt;
+
+    /**
+     * GTValues ordinal for this Recipe's base power tier
+     */
+    private int baseTier = -1;
 
     /**
      * If this Recipe is hidden from JEI
@@ -289,6 +298,22 @@ public class Recipe {
 
     public int getEUt() {
         return EUt;
+    }
+
+    /**
+     * @return The tier of machine required to run this recipe, as defined by {@link GTValues}
+     */
+    public int getBaseTier() {
+
+        // Lazily compute and store for later recall
+        if(baseTier == -1) {
+            int tier = binarySearch(GTValues.V, abs(EUt));
+            if(tier < 0)
+                tier = abs(tier + 1);
+            baseTier = tier;
+        }
+
+        return baseTier;
     }
 
     public boolean isHidden() {

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -475,10 +475,29 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
             '}';
     }
 
+    /**
+     * A ChanceFunction specifies alternative behavior applied to all chanced outputs, overriding
+     * the default {@code RecipeMap.chanceFunction}. The default behavior is additive, applying
+     * a flat bonus multiplied by the number of tiers the machine is above the base recipe tier.<br />
+     * <br />
+     * All integer parameters to this function and the resulting value express a "chance value" which
+     * is a percent chance out of 100 with two decimal places, multiplied by 100 to produce a resulting
+     * integer value. For example {@code 10000} is 100% and {@code 750} is 7.5%.<br />
+     * <br />
+     * Values can exceed 100% but chanced outputs will simply be guaranteed at or above 100% (you won't get twice
+     * the amount with 200%, for example). As long as the result of {@code chanceFor} is of the appropriate format,
+     * how exactly you compute the result doesn't really matter.
+     */
     @FunctionalInterface
     @ZenClass("mods.gregtech.recipe.IChanceFunction")
     @ZenRegister
     public interface IChanceFunction {
+        /**
+         * @param chance the base chance value
+         * @param boostPerTier the increase in chance value to apply per tier of boost
+         * @param boostTier the number of times to apply {@code boostPerTier}
+         * @return the computed chance value
+         */
         int chanceFor(int chance, int boostPerTier, int boostTier);
     }
 }


### PR DESCRIPTION
The chance function was incorrectly being supplied with the tier ordinal of the machine running the recipe, rather than the difference between the machine tier and the base recipe tier.

This resulted in bizarre chanced output scaling behavior, with more bonuses being applied than should have been.

The Recipe class has been enhanced to supply the base tier of the recipe (as a `GTValues` voltage tier ordinal) via `Recipe::getBaseTier()`, which is computed lazily and the result cached for subsequent lookups.

The chance function is now passed the difference between the machine's tier and the base recipe tier as the correct number of bonuses to apply.