### PR TITLE
Fix Version-related issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: Publish
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+' # any semver tag, e.g. 1.2.3
+      - '[0-9]+.[0-9]+.[0-9]+' # any semver tag, e.g. 1.2.3
 
 env:
   # link to the changelog with a format code for the version

--- a/src/main/java/gregtech/GregTechVersion.java
+++ b/src/main/java/gregtech/GregTechVersion.java
@@ -4,15 +4,7 @@ import gregtech.api.util.Version;
 
 public final class GregTechVersion {
 
-    public static final int MAJOR = 1;
-    //This number is incremented every major feature update
-    public static final int MINOR = 18;
-    //This number is incremented every time the feature is added, or bug is fixed. resets every major version change
-    public static final int REVISION = 0;
-    //This number is incremented every build, and never reset. Should always be 0 in the repo code.
-    public static final int BUILD = 0;
-
-    public static final Version VERSION = new Version(MAJOR, MINOR, REVISION, BUILD);
+    public static final Version VERSION = Version.parse(GTInternalTags.VERSION);
 
     private GregTechVersion() {
     }

--- a/src/main/java/gregtech/api/util/Version.java
+++ b/src/main/java/gregtech/api/util/Version.java
@@ -22,7 +22,7 @@ public class Version implements Comparable<Version> {
     }
 
     public static Version parse(String vStr) {
-        final Pattern p = Pattern.compile("(\\d+).*");
+        final Pattern p = Pattern.compile("v?(\\d+).*");
         return new Version(Arrays.stream(vStr.split(Pattern.quote(".")))
                                .map(s -> {
                                    Matcher m = p.matcher(s);

--- a/src/test/java/gregtech/api/util/VersionTest.java
+++ b/src/test/java/gregtech/api/util/VersionTest.java
@@ -1,0 +1,67 @@
+package gregtech.api.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class VersionTest {
+
+	/**
+	 * Workaround for Nomifactory 1.2.2.x worlds with Bansoukou-patched version string
+	 * so that they are properly remapped on world load
+	 */
+	@Test
+	public void parse_omits_text_after_numbers() {
+		String version = "1.8.4.419-exa3";
+		Version expected = new Version(1, 8, 4, 419);
+		assertEquals("Failed to omit non-numeric trailing text", expected, Version.parse(version));
+	}
+
+	/**
+	 * As a contingency against crashing, map non-numeric tokens to zeroes
+	 */
+	@Test public void parse_maps_text_to_zero() {
+		String version = "lorem.ipsum.foo.bar";
+		Version expected = new Version(0, 0, 0, 0);
+		assertEquals("Failed to map non-numeric text to zero", expected, Version.parse(version));
+	}
+
+	/**
+	 * If there's a preceding "v" which started getting added by the build script
+	 * when I switched to using git tags for version numbering, we need to ignore it
+	 * and consider just the number.
+	 */
+	@Test
+	public void parse_ignores_v_before_number() {
+		// Bug fix confirmation - formerly detected '0.18.1'
+		String version = "v1.18.1";
+		Version expected = new Version(1, 18, 1);
+		assertEquals("Failed to detect version string with single preceding 'v'", expected, Version.parse(version));
+	}
+
+	/**
+	 * Make sure that dev builds properly parse the version string too.
+	 */
+	@Test
+	public void parse_handles_RFG_dirty_tags() {
+		// RFG-generated version strings look like this when you have uncommitted changes
+		String version = "v1.18.1.dirty";
+		Version expected = new Version(1, 18, 1);
+		assertEquals("Failed to parse simple dirty tag", expected, Version.parse(version));
+
+		// RFG-generated version strings look like this when you have local commits plus uncommitted changes
+		version = "v1.18.1-2-abcdef12.dirty";
+		assertEquals("Failed to parse complex dirty tag", expected, Version.parse(version));
+	}
+
+	/**
+	 * Ensures that 'v' handling doesn't break other rules.
+	 */
+	@Test
+	public void parse_handles_other_v_conditions() {
+		// two 'v' counts as text, v followed by non-numbers is still text, single v is not ignored between digits
+		String version = "vv1.vfoo.1v8";
+		Version expected = new Version(0, 0, 1);
+		assertEquals("Parsing failed to handle normal logic with 'v' related conditions", expected, Version.parse(version));
+	}
+}


### PR DESCRIPTION
Fixes #9 

- `Version::parse` now ignores a single preceding v in an otherwise numeric token, so `v1.18.1` parses as `1.18.1` instead of `0.18.1`.
- Actually use the generated version details rather than the old hard-coded file
- Revert change to `publish.yml` tag glob pattern triggering build when pushing v-prefixed semver tags. Use plain semver tags for now.