### PR TITLE
Added configuration option for requiring silk touch to get ore variants.

### DIFF
--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -112,6 +112,9 @@ public class ConfigHolder {
     @Config.Comment("If false, machines will not make noise. Default: true")
     public static boolean doMachinesHaveSounds = true;
 
+    @Config.Comment("If true, all rock variants of ores will drop the stone variant unless the player uses Silk Touch. Default: false")
+    public static boolean requireSilkTouchForRockVariants = false;
+
     public static class VanillaRecipes {
 
         @Config.Comment("Whether to nerf the paper crafting recipe. Default: true")

--- a/src/main/java/gregtech/common/blocks/BlockOre.java
+++ b/src/main/java/gregtech/common/blocks/BlockOre.java
@@ -5,6 +5,7 @@ import gregtech.api.unification.material.type.DustMaterial;
 import gregtech.api.unification.ore.StoneType;
 import gregtech.api.util.IBlockOre;
 import gregtech.common.blocks.properties.PropertyStoneType;
+import gregtech.common.ConfigHolder;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFalling;
 import net.minecraft.block.SoundType;
@@ -12,7 +13,10 @@ import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Enchantments;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.NonNullList;
@@ -65,7 +69,18 @@ public class BlockOre extends BlockFalling implements IBlockOre {
 
     @Override
     public int damageDropped(IBlockState state) {
-        return getMetaFromState(state);
+        // Only drop the variants meta ID if:
+        // - The config option for requiring silk touch is disabled
+        // - OR The function was called without a harvester (needed for mod compatibility)
+        // - OR The harvester has an item with silk touch in their main hand
+        if (!ConfigHolder.requireSilkTouchForRockVariants ||
+                harvesters.get() == null ||
+                EnchantmentHelper.getEnchantments(harvesters.get().getHeldItemMainhand())
+                        .containsKey(Enchantments.SILK_TOUCH))
+            return getMetaFromState(state);
+
+        // otherwise, return the id of StoneType.STONE
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
**What:**
Currently all different ore block variants (eg. Marble, Stone, Basalt etc.) drop different items. Depending on the variety of rock types in an ore vein, this can result in tons of different items in the players inventory. This is especially frustrating for new players.

**How solved:**
This pull request adds an option (**disabled** by default) for those who want all ores to drop the stone variants. Similar to other blocks in the game, when the player is using Silk Touch, the actual variant of the block gets dropped, regardless of this config setting.

**Outcome:**
Added a configuration option for dropping the same item for all ore variants when Silk Touch is not used.

**Possible compatibility issue:**
~~TheOneProbe displays the wrong variant for the block when this configuration item is enabled. (It always shows stone)~~
**EDIT:** this is fixed now
![image](https://github.com/user-attachments/assets/23c9fb79-f64a-4b68-b6ed-04314cd8fcf1)