### PR TITLE
Rework Electric Tools

### DIFF
--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -17,6 +17,7 @@ import gregtech.api.items.OreDictNames;
 import gregtech.api.items.gui.ItemUIFactory;
 import gregtech.api.items.gui.PlayerInventoryHolder;
 import gregtech.api.items.metaitem.stats.*;
+import gregtech.api.items.toolitem.ToolMetaItem;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.ore.OrePrefix;
@@ -457,17 +458,36 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
         }
     }
 
+    private static long _getDamage(ItemStack itemStack) {
+        // Retrieve the tool damage from NBT if it's a tool, otherwise standard item damage
+        if(!itemStack.isEmpty() && itemStack.getItem() instanceof ToolMetaItem toolMetaItem)
+            return toolMetaItem.getItemDamage(itemStack);
+        return itemStack.getItemDamage();
+    }
+
+    // Prevent charging electric items from resetting block breaking every tick
+    @Override
+    public boolean shouldCauseBlockBreakReset(ItemStack oldStack, ItemStack newStack) {
+        return oldStack.getItem() != newStack.getItem() || _getDamage(oldStack) < _getDamage(newStack);
+    }
+
+    private static long _getCharge(ItemStack itemStack) {
+        // get the charge if this item has it
+        if(itemStack.hasCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null))
+            return itemStack.getCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null).getCharge();
+        // else return -1 (to ensure it doesn't match a merely discharged item)
+        return -1;
+    }
+
+    // Prevent electric tools from bobbing while charging
     @Override
     public boolean shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged) {
-        //if item is equal, and old item has electric item capability, remove charge tags to stop reequip animation when charge is altered
-        if(ItemStack.areItemsEqual(oldStack, newStack) && oldStack.hasCapability(GregtechCapabilities.CAPABILITY_ELECTRIC_ITEM, null) &&
-            oldStack.hasTagCompound() && newStack.hasTagCompound()) {
-            oldStack = oldStack.copy();
-            newStack = newStack.copy();
-            oldStack.getTagCompound().removeTag("Charge");
-            newStack.getTagCompound().removeTag("Charge");
-        }
-        return !ItemStack.areItemStacksEqual(oldStack, newStack);
+        // to prevent electric items from bobbing while charging, only animate when the slot changed
+        if(_getCharge(oldStack) != _getCharge(newStack))
+            return slotChanged;
+
+        // if the charges are identical, only animate if the old and new stacks are otherwise different
+        return !oldStack.equals(newStack);
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/toolitem/AbstractToolItemCapabilityProvider.java
+++ b/src/main/java/gregtech/api/items/toolitem/AbstractToolItemCapabilityProvider.java
@@ -20,7 +20,7 @@ public abstract class AbstractToolItemCapabilityProvider<T> implements ICapabili
     protected abstract Capability<T> getCapability();
 
     public boolean damageItem(int damage, boolean simulate) {
-        return ((IToolItem) itemStack.getItem()).damageItem(itemStack, damage, simulate);
+        return itemStack.getItem() instanceof IToolItem toolItem && toolItem.damageItem(itemStack, damage, simulate);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolChainsawHV.java
+++ b/src/main/java/gregtech/common/tools/ToolChainsawHV.java
@@ -8,31 +8,6 @@ import net.minecraft.item.ItemStack;
 public class ToolChainsawHV extends ToolChainsawLV {
 
     @Override
-    public int getToolDamagePerBlockBreak(ItemStack stack) {
-        return 8;
-    }
-
-    @Override
-    public int getToolDamagePerDropConversion(ItemStack stack) {
-        return 16;
-    }
-
-    @Override
-    public int getToolDamagePerContainerCraft(ItemStack stack) {
-        return 128;
-    }
-
-    @Override
-    public int getToolDamagePerEntityAttack(ItemStack stack) {
-        return 32;
-    }
-
-    @Override
-    public int getBaseQuality(ItemStack stack) {
-        return 1;
-    }
-
-    @Override
     public float getBaseDamage(ItemStack stack) {
         return 6.0F;
     }
@@ -44,7 +19,7 @@ public class ToolChainsawHV extends ToolChainsawLV {
 
     @Override
     public float getMaxDurabilityMultiplier(ItemStack stack) {
-        return 40.0F;
+        return 20.0F;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolChainsawLV.java
+++ b/src/main/java/gregtech/common/tools/ToolChainsawLV.java
@@ -15,11 +15,6 @@ public class ToolChainsawLV extends ToolSaw {
     }
 
     @Override
-    public int getToolDamagePerContainerCraft(ItemStack stack) {
-        return 8;
-    }
-
-    @Override
     public float getBaseDamage(ItemStack stack) {
         return 4.0F;
     }
@@ -31,7 +26,7 @@ public class ToolChainsawLV extends ToolSaw {
 
     @Override
     public float getMaxDurabilityMultiplier(ItemStack stack) {
-        return 10.0f;
+        return 5.0f;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolChainsawMV.java
+++ b/src/main/java/gregtech/common/tools/ToolChainsawMV.java
@@ -8,31 +8,6 @@ import net.minecraft.item.ItemStack;
 public class ToolChainsawMV extends ToolChainsawLV {
 
     @Override
-    public int getToolDamagePerBlockBreak(ItemStack stack) {
-        return 2;
-    }
-
-    @Override
-    public int getToolDamagePerDropConversion(ItemStack stack) {
-        return 4;
-    }
-
-    @Override
-    public int getToolDamagePerContainerCraft(ItemStack stack) {
-        return 32;
-    }
-
-    @Override
-    public int getToolDamagePerEntityAttack(ItemStack stack) {
-        return 8;
-    }
-
-    @Override
-    public int getBaseQuality(ItemStack stack) {
-        return 1;
-    }
-
-    @Override
     public float getBaseDamage(ItemStack stack) {
         return 5.0F;
     }
@@ -44,7 +19,7 @@ public class ToolChainsawMV extends ToolChainsawLV {
 
     @Override
     public float getMaxDurabilityMultiplier(ItemStack stack) {
-        return 20.0F;
+        return 10.0F;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolDrillHV.java
+++ b/src/main/java/gregtech/common/tools/ToolDrillHV.java
@@ -8,31 +8,6 @@ import net.minecraft.item.ItemStack;
 public class ToolDrillHV extends ToolDrillLV {
 
     @Override
-    public int getToolDamagePerBlockBreak(ItemStack stack) {
-        return 8;
-    }
-
-    @Override
-    public int getToolDamagePerDropConversion(ItemStack stack) {
-        return 16;
-    }
-
-    @Override
-    public int getToolDamagePerContainerCraft(ItemStack stack) {
-        return 128;
-    }
-
-    @Override
-    public int getToolDamagePerEntityAttack(ItemStack stack) {
-        return 32;
-    }
-
-    @Override
-    public int getBaseQuality(ItemStack stack) {
-        return 1;
-    }
-
-    @Override
     public float getBaseDamage(ItemStack stack) {
         return 5.0F;
     }

--- a/src/main/java/gregtech/common/tools/ToolDrillLV.java
+++ b/src/main/java/gregtech/common/tools/ToolDrillLV.java
@@ -13,7 +13,8 @@ public class ToolDrillLV extends ToolBase {
 
     @Override
     public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
-        return enchantment.type.canEnchantItem(Items.IRON_PICKAXE) ||
+        return enchantment.type != null &&
+            enchantment.type.canEnchantItem(Items.IRON_PICKAXE) ||
             enchantment.type.canEnchantItem(Items.IRON_SHOVEL);
     }
 

--- a/src/main/java/gregtech/common/tools/ToolDrillMV.java
+++ b/src/main/java/gregtech/common/tools/ToolDrillMV.java
@@ -8,31 +8,6 @@ import net.minecraft.item.ItemStack;
 public class ToolDrillMV extends ToolDrillLV {
 
     @Override
-    public int getToolDamagePerBlockBreak(ItemStack stack) {
-        return 2;
-    }
-
-    @Override
-    public int getToolDamagePerDropConversion(ItemStack stack) {
-        return 4;
-    }
-
-    @Override
-    public int getToolDamagePerContainerCraft(ItemStack stack) {
-        return 32;
-    }
-
-    @Override
-    public int getToolDamagePerEntityAttack(ItemStack stack) {
-        return 8;
-    }
-
-    @Override
-    public int getBaseQuality(ItemStack stack) {
-        return 1;
-    }
-
-    @Override
     public float getBaseDamage(ItemStack stack) {
         return 4.0F;
     }

--- a/src/main/java/gregtech/common/tools/ToolSaw.java
+++ b/src/main/java/gregtech/common/tools/ToolSaw.java
@@ -26,7 +26,8 @@ public class ToolSaw extends ToolBase {
 
     @Override
     public boolean canApplyEnchantment(ItemStack stack, Enchantment enchantment) {
-        return enchantment.type.canEnchantItem(Items.IRON_AXE);
+        return enchantment.type != null
+            && enchantment.type.canEnchantItem(Items.IRON_AXE);
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolScrewdriver.java
+++ b/src/main/java/gregtech/common/tools/ToolScrewdriver.java
@@ -3,15 +3,14 @@ package gregtech.common.tools;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntitySpider;
 import net.minecraft.item.ItemStack;
 
 public class ToolScrewdriver extends ToolBase {
 
     @Override
     public float getNormalDamageBonus(EntityLivingBase entity, ItemStack stack, EntityLivingBase attacker) {
-        String name = entity.getClass().getName();
-        name = name.substring(name.lastIndexOf('.') + 1);
-        return name.toLowerCase().contains("spider") ? 3.0F : 1.0F;
+        return entity.getClass().isAssignableFrom(EntitySpider.class) ? 3.0F : 1.0F;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolScrewdriverLV.java
+++ b/src/main/java/gregtech/common/tools/ToolScrewdriverLV.java
@@ -14,7 +14,7 @@ public class ToolScrewdriverLV extends ToolScrewdriver {
 
     @Override
     public float getMaxDurabilityMultiplier(ItemStack stack) {
-        return 10.0f;
+        return 5.0f;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolWrench.java
+++ b/src/main/java/gregtech/common/tools/ToolWrench.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntityGolem;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
@@ -13,9 +14,7 @@ public class ToolWrench extends ToolBase {
 
     @Override
     public float getNormalDamageBonus(EntityLivingBase entity, ItemStack stack, EntityLivingBase attacker) {
-        String name = entity.getClass().getName();
-        name = name.substring(name.lastIndexOf('.') + 1);
-        return name.toLowerCase().contains("golem") ? 3.0F : 1.0F;
+        return entity.getClass().isAssignableFrom(EntityGolem.class) ? 3.0F : 1.0F;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolWrenchHV.java
+++ b/src/main/java/gregtech/common/tools/ToolWrenchHV.java
@@ -8,33 +8,8 @@ import net.minecraft.item.ItemStack;
 public class ToolWrenchHV extends ToolWrenchLV {
 
     @Override
-    public int getToolDamagePerBlockBreak(ItemStack stack) {
-        return 8;
-    }
-
-    @Override
-    public int getToolDamagePerDropConversion(ItemStack stack) {
-        return 16;
-    }
-
-    @Override
-    public int getToolDamagePerContainerCraft(ItemStack stack) {
-        return 128;
-    }
-
-    @Override
-    public int getToolDamagePerEntityAttack(ItemStack stack) {
-        return 32;
-    }
-
-    @Override
-    public int getBaseQuality(ItemStack stack) {
-        return 1;
-    }
-
-    @Override
     public float getBaseDamage(ItemStack stack) {
-        return 2.0F;
+        return 6.0F;
     }
 
     @Override
@@ -44,7 +19,7 @@ public class ToolWrenchHV extends ToolWrenchLV {
 
     @Override
     public float getMaxDurabilityMultiplier(ItemStack stack) {
-        return 40.0F;
+        return 20.0F;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolWrenchLV.java
+++ b/src/main/java/gregtech/common/tools/ToolWrenchLV.java
@@ -8,6 +8,11 @@ import net.minecraft.item.ItemStack;
 public class ToolWrenchLV extends ToolWrench {
 
     @Override
+    public float getBaseDamage(ItemStack stack) {
+        return 4.0F;
+    }
+
+    @Override
     public int getToolDamagePerBlockBreak(ItemStack stack) {
         return 1;
     }
@@ -19,7 +24,7 @@ public class ToolWrenchLV extends ToolWrench {
 
     @Override
     public float getMaxDurabilityMultiplier(ItemStack stack) {
-        return 10.0f;
+        return 5.0f;
     }
 
     @Override

--- a/src/main/java/gregtech/common/tools/ToolWrenchMV.java
+++ b/src/main/java/gregtech/common/tools/ToolWrenchMV.java
@@ -8,33 +8,8 @@ import net.minecraft.item.ItemStack;
 public class ToolWrenchMV extends ToolWrenchLV {
 
     @Override
-    public int getToolDamagePerBlockBreak(ItemStack stack) {
-        return 2;
-    }
-
-    @Override
-    public int getToolDamagePerDropConversion(ItemStack stack) {
-        return 4;
-    }
-
-    @Override
-    public int getToolDamagePerContainerCraft(ItemStack stack) {
-        return 32;
-    }
-
-    @Override
-    public int getToolDamagePerEntityAttack(ItemStack stack) {
-        return 8;
-    }
-
-    @Override
-    public int getBaseQuality(ItemStack stack) {
-        return 1;
-    }
-
-    @Override
     public float getBaseDamage(ItemStack stack) {
-        return 1.5F;
+        return 5.0F;
     }
 
     @Override
@@ -44,7 +19,7 @@ public class ToolWrenchMV extends ToolWrenchLV {
 
     @Override
     public float getMaxDurabilityMultiplier(ItemStack stack) {
-        return 20.0F;
+        return 10.0F;
     }
 
     @Override


### PR DESCRIPTION
Electric Tools as implemented by GTCE were a mess for a variety of reasons.

The durability was nominally increased with each tier of electric tool, but the amount of damage the tools took was also increased, making it hard to reason about the actual amount of durability.

For example, the LV chainsaw took 8 damage instead of a standard saw's 2 damage from crafting table use, reducing its nominal 10x durability to more like 2.5x for this purpose. The HV chainsaw took 128 damage for the same operation, reducing its nominal 40x durability to less than 1x.

Similarly, damage from breaking blocks increased from 1 (LV) to 2 (MV) to 8 (HV), so the effective durability multipliers were 10x, 10x, 5x.

Removing this damage scaling allows for less confusing results and clear benefits to higher tier tools.

Additionally, electric tools were impossible to use while charging, which made them really annoying to use. Some changes to the `MetaItem` class allow for preventing both the re-equip animation bobbing and interruption of ongoing block breaking.

There was also an inexplicable gain of one additional harvest level when using MV and HV tools.

I have therefore rebalanced the electric tools as follows:

- MV/HV tools no longer gain +1 harvest level
- Electric tools no longer take more damage than the base tool
- Adjust for the above by setting durability for tiered electric tools to 5/10/20x, except drills (10/20/40x, as before)
- Electric Wrench base attack damage is now 4/5/6 (was 3)