### PR TITLE
Add Supply Unique mode to Robot Arms and Fluid Regulators

### DIFF
--- a/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
+++ b/src/main/java/gregtech/common/covers/CoverFluidRegulator.java
@@ -54,17 +54,23 @@ public class CoverFluidRegulator extends CoverPump {
             case TRANSFER_ANY: return GTFluidUtils.transferFluids(sourceHandler, destHandler, transferLimit, fluidFilter::testFluidStack);
             case KEEP_EXACT: return doKeepExact(transferLimit, sourceHandler, destHandler, fluidFilter::testFluidStack, this.keepAmount);
             case TRANSFER_EXACT: return doTransferExact(transferLimit, sourceHandler, destHandler, fluidFilter::testFluidStack, this.supplyAmount);
+            case TRANSFER_UNIQUE: return doTransferExact(transferLimit, sourceHandler, destHandler, fluidFilter::testFluidStack, this.supplyAmount, true);
         }
         return 0;
     }
 
     protected int doTransferExact(int transferLimit, IFluidHandler sourceHandler, IFluidHandler destHandler, Predicate<FluidStack> fluidFilter, int supplyAmount) {
+        return doTransferExact(transferLimit, sourceHandler, destHandler, fluidFilter, supplyAmount, false);
+    }
+
+    protected int doTransferExact(int transferLimit, IFluidHandler sourceHandler, IFluidHandler destHandler, Predicate<FluidStack> fluidFilter, int supplyAmount, boolean unique) {
         int fluidLeftToTransfer = transferLimit;
         for (IFluidTankProperties tankProperties : sourceHandler.getTankProperties()) {
             if (fluidLeftToTransfer < supplyAmount)
                 break;
             FluidStack sourceFluid = tankProperties.getContents();
             if (sourceFluid == null || sourceFluid.amount == 0 || !fluidFilter.test(sourceFluid)) continue;
+            if(unique && containsFluid(tankProperties.getContents(), destHandler.getTankProperties())) continue;
             sourceFluid.amount = supplyAmount;
             if (GTFluidUtils.transferExactFluidStack(sourceHandler, destHandler, sourceFluid.copy())) {
                 fluidLeftToTransfer -= sourceFluid.amount;
@@ -72,6 +78,19 @@ public class CoverFluidRegulator extends CoverPump {
             if (fluidLeftToTransfer == 0) break;
         }
         return transferLimit - fluidLeftToTransfer;
+    }
+
+    /**
+     * @param needle the target fluid
+     * @param haystack the destination's tank properties
+     * @return true if {@code needle} is not {@code null} and matches the fluid in any tank in {@code haystack}
+     */
+    private boolean containsFluid(FluidStack needle, IFluidTankProperties[] haystack) {
+        if(needle != null)
+            for(var element : haystack)
+                if(needle.isFluidEqual(element.getContents()))
+                    return true;
+        return false;
     }
 
     /**
@@ -208,7 +227,9 @@ public class CoverFluidRegulator extends CoverPump {
     }
 
     private boolean checkTransferMode() {
-        return this.transferMode == TransferMode.TRANSFER_EXACT || this.transferMode == TransferMode.KEEP_EXACT;
+        return this.transferMode == TransferMode.TRANSFER_EXACT ||
+            this.transferMode == TransferMode.KEEP_EXACT ||
+            this.transferMode == TransferMode.TRANSFER_UNIQUE;
     }
 
     private String getTransferSizeString() {
@@ -218,6 +239,7 @@ public class CoverFluidRegulator extends CoverPump {
                 val = keepAmount;
                 break;
             case TRANSFER_EXACT:
+            case TRANSFER_UNIQUE:
                 val = supplyAmount;
                 break;
             default: val = -1;
@@ -242,6 +264,12 @@ public class CoverFluidRegulator extends CoverPump {
                 supplyComponent.getStyle().setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverSupply));
                 textList.add(supplyComponent);
                 break;
+            case TRANSFER_UNIQUE:
+                ITextComponent uniqueComponent = new TextComponentString(getTransferSizeString());
+                TextComponentTranslation hoverUnique = new TextComponentTranslation("cover.fluid_regulator.supply_unique", this.supplyAmount);
+                uniqueComponent.getStyle().setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, hoverUnique));
+                textList.add(uniqueComponent);
+                break;
         }
     }
 
@@ -258,6 +286,7 @@ public class CoverFluidRegulator extends CoverPump {
         amount *= this.bucketMode == BucketMode.BUCKET ? 1000 : 1;
         switch(this.transferMode) {
             case TRANSFER_EXACT:
+            case TRANSFER_UNIQUE:
                 setSupplyAmount(MathHelper.clamp(this.supplyAmount + amount, 0, this.transferRate));
             case KEEP_EXACT:
                 setKeepAmount(MathHelper.clamp(this.keepAmount + amount, 0, Integer.MAX_VALUE));

--- a/src/main/java/gregtech/common/covers/CoverRoboticArm.java
+++ b/src/main/java/gregtech/common/covers/CoverRoboticArm.java
@@ -46,18 +46,30 @@ public class CoverRoboticArm extends CoverConveyor {
             case TRANSFER_ANY: return doTransferItemsAny(itemHandler, myItemHandler, maxTransferAmount);
             case TRANSFER_EXACT: return doTransferExact(itemHandler, myItemHandler, maxTransferAmount);
             case KEEP_EXACT: return doKeepExact(itemHandler, myItemHandler, maxTransferAmount);
+            case TRANSFER_UNIQUE: return doTransferExact(itemHandler, myItemHandler, maxTransferAmount, true);
             default: return 0;
         }
     }
 
     protected int doTransferExact(IItemHandler itemHandler, IItemHandler myItemHandler, int maxTransferAmount) {
+        return doTransferExact(itemHandler, myItemHandler, maxTransferAmount, false);
+    }
+
+    protected int doTransferExact(IItemHandler itemHandler, IItemHandler myItemHandler, int maxTransferAmount, boolean unique) {
         Map<ItemStackKey, TypeItemInfo> sourceItemAmount = doCountSourceInventoryItemsByType(itemHandler, myItemHandler);
+        Map<ItemStackKey, TypeItemInfo> destItemAmount   = doCountSourceInventoryItemsByType(myItemHandler, itemHandler);
         Iterator<ItemStackKey> iterator = sourceItemAmount.keySet().iterator();
         ItemStack filter = this.itemFilterContainer.getFilterInventory().getStackInSlot(0);
         boolean smartFilter = MetaItems.SMART_FILTER.isItemEqual(filter);
         while (iterator.hasNext()) {
             ItemStackKey key = iterator.next();
             TypeItemInfo sourceInfo = sourceItemAmount.get(key);
+
+            if(unique && destItemAmount.containsKey(key)) {
+                iterator.remove();
+                continue;
+            }
+
             int itemAmount = sourceInfo.totalCount;
             Set<ItemStackKey> matchedItems = Collections.singleton(key);
             int itemToMoveAmount = itemFilterContainer.getSlotTransferLimit(sourceInfo.filterSlot, matchedItems);
@@ -132,8 +144,8 @@ public class CoverRoboticArm extends CoverConveyor {
 
         // restrict general rate to 1024 so filters don't overflow
         int limit = 1024;
-        // restrict Supply Exact to maximum transfer per second
-        if(transferMode == TransferMode.TRANSFER_EXACT)
+        // restrict Supply Exact and Unique to maximum transfer per second
+        if(transferMode == TransferMode.TRANSFER_EXACT || transferMode == TransferMode.TRANSFER_UNIQUE)
             limit = this.maxItemTransferRate;
 
         this.itemFilterContainer.setMaxStackSize(limit);

--- a/src/main/java/gregtech/common/covers/TransferMode.java
+++ b/src/main/java/gregtech/common/covers/TransferMode.java
@@ -5,7 +5,8 @@ import net.minecraft.util.IStringSerializable;
 public enum TransferMode implements IStringSerializable {
         TRANSFER_ANY("cover.robotic_arm.transfer_mode.transfer_any", Integer.MAX_VALUE),
         TRANSFER_EXACT("cover.robotic_arm.transfer_mode.transfer_exact", 1024),
-        KEEP_EXACT("cover.robotic_arm.transfer_mode.keep_exact", 1024);
+        KEEP_EXACT("cover.robotic_arm.transfer_mode.keep_exact", 1024),
+        TRANSFER_UNIQUE("cover.robotic_arm.transfer_mode.transfer_unique", 1024);
 
         public final String localeName;
         public final int maxStackSize;

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -751,7 +751,8 @@ cover.robotic_arm.title=Robotic Arm Settings (%s)
 cover.robotic_arm.transfer_mode.transfer_any=Transfer Any
 cover.robotic_arm.transfer_mode.transfer_exact=Supply Exact
 cover.robotic_arm.transfer_mode.keep_exact=Keep Exact
-cover.robotic_arm.transfer_mode.description=§eTransfer Any§r - in this mode, cover will transfer as many items matching its filter as possible./n§eSupply Exact§r - in this mode, cover will supply items in portions specified in item filter slots (or variable under this button for ore dictionary filter). If amount of items is less than portion size, items won't be moved. If using a Smart Filter, the variable is a multiplier./n§eKeep Exact§r - in this mode, cover will keep specified amount of items in the destination inventory, supplying additional amount of items if required./n§7Tip: left/right click on filter slots to change item amount. Use shift-clicking to change the amount faster.
+cover.robotic_arm.transfer_mode.transfer_unique=Supply Unique
+cover.robotic_arm.transfer_mode.description=§eTransfer Any§r - in this mode, cover will transfer as many items matching its filter as possible./n§eSupply Exact§r - in this mode, cover will supply items in portions specified in item filter slots (or variable under this button for ore dictionary filter). If amount of items is less than portion size, items won't be moved. If using a Smart Filter, the variable is a multiplier./n§eKeep Exact§r - in this mode, cover will keep specified amount of items in the destination inventory, supplying additional amount of items if required./n§eSupply Unique§r - same as Supply Exact, but will only transfer items not already in the destination./n§7Tip: left/right click on filter slots to change item amount. Use shift-clicking to change the amount faster.
 
 cover.pump.title=Pump Cover Settings (%s)
 cover.pump.transfer_rate=%s

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -762,9 +762,10 @@ cover.pump.fluid_filter.title=Fluid Filter
 cover.bucket.mode.bucket=B/s
 cover.bucket.mode.milli_bucket=mB/s
 cover.fluid_regulator.title=Fluid Regulator Settings (%s)
-cover.fluid_regulator.transfer_mode.description=§eTransfer Any§r - in this mode, cover will transfer as many fluids matching its filter as possible./n§eSupply Exact§r - in this mode, cover will supply fluids in portions specified in the window underneath this button. If amount of fluids is less than portion size, fluids won't be moved./n§eKeep Exact§r - in this mode, cover will keep specified amount of fluids in the destination inventory, supplying additional amount of fluids if required./n§7Tip: shift click will multiply increase/decrease amounts by 10 and ctrl click will multiply by 100.
+cover.fluid_regulator.transfer_mode.description=§eTransfer Any§r - in this mode, cover will transfer as many fluids matching its filter as possible./n§eSupply Exact§r - in this mode, cover will supply fluids in portions specified in the window underneath this button. If amount of fluids is less than portion size, fluids won't be moved./n§eKeep Exact§r - in this mode, cover will keep specified amount of fluids in the destination inventory, supplying additional amount of fluids if required./n§eSupply Unique§r - same as Supply Exact, but will only transfer fluids not already in the destination./n§7Tip: shift click will multiply increase/decrease amounts by 10 and ctrl click will multiply by 100.
 cover.fluid_regulator.supply_exact=Supply Exact: %s
 cover.fluid_regulator.keep_exact=Keep Exact: %s
+cover.fluid_regulator.supply_unique=Supply Unique: %s
 
 cover.machine_controller.name=Machine Controller Settings
 cover.machine_controller.normal=Normal


### PR DESCRIPTION
Supply Unique is a new transfer mode for Robot Arms and Fluid Regulators which will move whole quantities of items like Supply Exact, but will only move items not already present in the destination. It's sort of a middle ground between Supply Exact and Keep Exact.

For example: if you tell a Robot Arm to Supply Exact 9 rubber pulp and 1 sulfur into a fast chemical reactor, it may keep supplying rubber pulp until the destination is full and never supply the sulfur. If you tell the Robot Arm instead to Keep Exact 9 rubber pulp and 1 sulfur, the machine will fill with partial quantities of rubber pulp, preventing it from running other such recipes you have enough of the "pulp" (like styrene-butadiene or silicone rubber).

In this situation, Supply Unique would move no more or less than 9 rubber pulp, then stop for that item because the destination now contains rubber pulp. It would then move 1 sulfur and stop, and the craft would start. If you only had 3 more rubber pulp but 9 polydimethylsiloxane dust, it could move that instead to make silicone rubber, followed by 1 sulfur to start the next craft.

This is perhaps a bit of a contrived example but it will also work with Smart Item Filters so you can evenly split batches of items between several Electrolyzers, for example.

It works the same for fluid regulators: supply an exact amount of each fluid then no longer supply that fluid until it is all gone.