### PR TITLE
Add click-and-drag support from HEI bookmarks pane

### DIFF
--- a/src/main/java/gregtech/api/gui/igredient/IGhostIngredientTarget.java
+++ b/src/main/java/gregtech/api/gui/igredient/IGhostIngredientTarget.java
@@ -8,4 +8,13 @@ public interface IGhostIngredientTarget {
 
     List<Target<?>> getPhantomTargets(Object ingredient);
 
+    /** Clamps and casts {@code in} to an {@code int} valued between {@code 1} and {@code Integer.MAX_VALUE} */
+    default int clampLong(long in) {
+        if(in <= 1L)
+            return 1;
+        if(in > Integer.MAX_VALUE)
+            return Integer.MAX_VALUE;
+        return (int) in;
+    }
+
 }

--- a/src/main/java/gregtech/api/gui/widgets/Bookmark.java
+++ b/src/main/java/gregtech/api/gui/widgets/Bookmark.java
@@ -25,7 +25,7 @@ public class Bookmark {
         Method daTmp;
 
         try {
-            bmTemp = Class.forName("mezz.jei.bookmarks.BookmarkItem", false, PhantomFluidWidget.class.getClassLoader());
+            bmTemp = Class.forName("mezz.jei.bookmarks.BookmarkItem", false, Bookmark.class.getClassLoader());
         } catch(ClassNotFoundException e) {
             bmTemp = null;
         }

--- a/src/main/java/gregtech/api/gui/widgets/Bookmark.java
+++ b/src/main/java/gregtech/api/gui/widgets/Bookmark.java
@@ -1,0 +1,155 @@
+package gregtech.api.gui.widgets;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+/**
+ * Loads HEI's {@code BookmarkItem} class via reflection and encapsulates interactions with it to maintain
+ * backwards-compatibility with JEI while supporting click-and-drag from the HEI bookmarks panel.
+ */
+public class Bookmark {
+    private static final Class<?> bookmarkItemClass;
+    private static final Field bookmarkIngredientField;
+    private static final Method bookmarkDisplayAmount;
+
+    static {
+        Class<?> bmTemp;
+        Field ingTmp;
+        Method daTmp;
+
+        try {
+            bmTemp = Class.forName("mezz.jei.bookmarks.BookmarkItem", false, PhantomFluidWidget.class.getClassLoader());
+        } catch(ClassNotFoundException e) {
+            bmTemp = null;
+        }
+        bookmarkItemClass = bmTemp;
+        if(bookmarkItemClass != null) {
+            try {
+                ingTmp = bookmarkItemClass.getDeclaredField("ingredient");
+            } catch(NoSuchFieldException e) {
+                ingTmp = null;
+            }
+            try {
+                daTmp = bookmarkItemClass.getDeclaredMethod("getDisplayAmount");
+            } catch(NoSuchMethodException e) {
+                daTmp = null;
+            }
+        } else {
+            ingTmp = null;
+            daTmp = null;
+        }
+        bookmarkIngredientField = ingTmp;
+        bookmarkDisplayAmount = daTmp;
+
+    }
+
+    private final Object bookmark;
+    private Bookmark(@NotNull Object in) {
+        this.bookmark = in;
+    }
+
+    /** @throws RuntimeException if {@code in} is not a BookmarkItem */
+    @NotNull
+    public static Bookmark wrap(@NotNull Object in) {
+        if(isBookmark(in))
+            return new Bookmark(in);
+        throw new RuntimeException("Skill Issue");
+    }
+
+    public static void ifIsItemBookmark(Object in, Consumer<Bookmark> handler) {
+        if(isItemBookmark(in))
+            handler.accept(wrap(in));
+    }
+
+    /** @return {@code true} if {@code in} is a bookmark wrapping a FluidStack */
+    @Contract(pure = true)
+    public static boolean isFluidBookmark(Object in) {
+        return (isBookmark(in) && getIngredient(in) instanceof FluidStack);
+    }
+
+    public void ifHasFluid(Consumer<FluidStack> fs) {
+        if(hasFluid())
+            fs.accept(getFluid());
+    }
+
+    public boolean hasFluid() {
+        return getIngredient() instanceof FluidStack;
+    }
+
+    @Nullable
+    public FluidStack getFluid() {
+        return getIngredient() instanceof FluidStack stack ? stack : null;
+    }
+
+    @Nullable
+    public static FluidStack getFluid(Object in) {
+        return getIngredient(in) instanceof FluidStack stack ? stack : null;
+    }
+
+    /** @return {@code true} if {@code in} is a bookmark wrapping an ItemStack */
+    @Contract(pure = true)
+    public static boolean isItemBookmark(Object in) {
+        return (isBookmark(in) && getIngredient(in) instanceof ItemStack);
+    }
+
+    public void ifHasItem(Consumer<ItemStack> is) {
+        if(hasItem())
+            is.accept(getItem());
+    }
+
+    public boolean hasItem() {
+        return getIngredient() instanceof ItemStack;
+    }
+
+    @Nullable
+    public ItemStack getItem() {
+        return getIngredient() instanceof ItemStack stack ? stack : null;
+    }
+
+    @Nullable
+    public static ItemStack getItem(Object in) {
+        return getIngredient(in) instanceof ItemStack stack ? stack : null;
+    }
+
+    @Contract(pure = true)
+    public static boolean isBookmark(Object in) {
+        if(bookmarkItemClass != null)
+            return bookmarkItemClass.isAssignableFrom(in.getClass());
+        return false;
+    }
+
+    @Contract(pure = true)
+    public static @Nullable Object getIngredient(Object o) {
+        if(bookmarkIngredientField != null)
+            try {
+                return bookmarkIngredientField.get(o);
+            } catch (Exception ignored) {}
+        return null;
+    }
+
+    @Contract(pure = true)
+    public static @Nullable Long getDisplayAmount(Object o) {
+        if(bookmarkDisplayAmount != null)
+            try {
+                return (long) bookmarkDisplayAmount.invoke(o);
+            } catch(Exception ignored) {}
+        return null;
+    }
+
+    public Object getIngredient() {
+        return getIngredient(bookmark);
+    }
+
+    public long getDisplayAmount() {
+        Long amount = getDisplayAmount(bookmark);
+        return amount != null ? amount : 0L;
+    }
+
+}

--- a/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
@@ -11,7 +11,6 @@ import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
 import mezz.jei.api.gui.IGhostIngredientHandler.Target;
-import mezz.jei.bookmarks.BookmarkItem;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -27,6 +26,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import static gregtech.api.gui.widgets.Bookmark.*;
 
 public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhostIngredientTarget {
 
@@ -51,9 +52,22 @@ public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhos
         return null;
     }
 
+    // Usable if the ingredient is a fluid, a drainable item, or a bookmark containing either
+    protected boolean isUsable(Object ingredient) {
+        if(ingredient instanceof FluidStack)
+            return true;
+        if(ingredient instanceof ItemStack stack && drainFrom(stack) != null)
+            return true;
+        if(isBookmark(ingredient)) {
+            Bookmark bookmark = wrap(ingredient);
+            return bookmark.hasFluid() || (bookmark.hasItem() && drainFrom(bookmark.getItem()) != null);
+        }
+        return false;
+    }
+
     @Override
     public List<Target<?>> getPhantomTargets(Object ingredient) {
-        if (!(ingredient instanceof FluidStack || ingredient instanceof BookmarkItem)  && drainFrom(ingredient) == null)
+        if (!isUsable(ingredient))
             return Collections.emptyList();
 
         Rectangle rectangle = toRectangleBox();
@@ -66,25 +80,33 @@ public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhos
 
             @Override
             public void accept(@NotNull Object ingredient) {
-                FluidStack ingredientStack = null;
-                if (ingredient instanceof BookmarkItem bookmark)
-                    if (bookmark.ingredient instanceof FluidStack stack) {
-                        ingredientStack = stack.copy();
-                        if(bookmark.getDisplayAmount() != 0)
-                            ingredientStack.amount = clampLong(bookmark.getDisplayAmount());
-                    } else if (bookmark.ingredient instanceof ItemStack is) {
-                        ItemStack temp = is.copy();
+                if(ingredient instanceof FluidStack stack)
+                    finish(stack);
+                else if (ingredient instanceof ItemStack) {
+                    FluidStack drained;
+                    if((drained = drainFrom(ingredient)) != null)
+                        finish(drained);
+                } else if (isBookmark(ingredient)) {
+                    Bookmark bookmark = wrap(ingredient);
+                    bookmark.ifHasFluid(fluid -> {
+                        FluidStack copy = fluid.copy();
+                        if (bookmark.getDisplayAmount() != 0)
+                            copy.amount = clampLong(bookmark.getDisplayAmount());
+                        finish(copy);
+                    });
+                    bookmark.ifHasItem(item -> {
+                        ItemStack temp = item.copy();
                         temp.setCount(clampLong(bookmark.getDisplayAmount()));
-                        ingredient = temp;
-                    }
-
-                if (ingredientStack == null)
-                    ingredientStack = drainFrom(ingredient);
-
-                if (ingredientStack != null) {
-                    NBTTagCompound tagCompound = ingredientStack.writeToNBT(new NBTTagCompound());
-                    writeClientAction(2, buffer -> buffer.writeCompoundTag(tagCompound));
+                        FluidStack drained = drainFrom(temp);
+                        if (drained != null)
+                            finish(drained);
+                    });
                 }
+            }
+
+            private void finish(FluidStack stack) {
+                NBTTagCompound tagCompound = stack.writeToNBT(new NBTTagCompound());
+                writeClientAction(2, buffer -> buffer.writeCompoundTag(tagCompound));
             }
         });
     }

--- a/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
@@ -11,6 +11,7 @@ import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
 import mezz.jei.api.gui.IGhostIngredientHandler.Target;
+import mezz.jei.bookmarks.BookmarkItem;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -18,6 +19,7 @@ import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
 import java.io.IOException;
@@ -30,8 +32,8 @@ public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhos
 
     protected TextureArea backgroundTexture = GuiTextures.FLUID_SLOT;
 
-    private Supplier<FluidStack> fluidStackSupplier;
-    private Consumer<FluidStack> fluidStackUpdater;
+    private final Supplier<FluidStack> fluidStackSupplier;
+    private final Consumer<FluidStack> fluidStackUpdater;
     protected FluidStack lastFluidStack;
 
     public PhantomFluidWidget(int xPosition, int yPosition, int width, int height, Supplier<FluidStack> fluidStackSupplier, Consumer<FluidStack> fluidStackUpdater) {
@@ -40,9 +42,8 @@ public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhos
         this.fluidStackUpdater = fluidStackUpdater;
     }
 
-    private FluidStack drainFrom(Object ingredient) {
-        if (ingredient instanceof ItemStack) {
-            ItemStack itemStack = (ItemStack) ingredient;
+    private static FluidStack drainFrom(Object ingredient) {
+        if (ingredient instanceof ItemStack itemStack) {
             IFluidHandlerItem fluidHandler = itemStack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
             if (fluidHandler != null)
                 return fluidHandler.drain(Integer.MAX_VALUE, false);
@@ -52,23 +53,32 @@ public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhos
 
     @Override
     public List<Target<?>> getPhantomTargets(Object ingredient) {
-        if (!(ingredient instanceof FluidStack) && drainFrom(ingredient) == null) {
+        if (!(ingredient instanceof FluidStack || ingredient instanceof BookmarkItem)  && drainFrom(ingredient) == null)
             return Collections.emptyList();
-        }
 
         Rectangle rectangle = toRectangleBox();
-        return Lists.newArrayList(new Target<Object>() {
+        return Lists.newArrayList(new Target<>() {
             @Override
+            @NotNull
             public Rectangle getArea() {
                 return rectangle;
             }
 
             @Override
-            public void accept(Object ingredient) {
-                FluidStack ingredientStack;
-                if (ingredient instanceof FluidStack)
-                    ingredientStack = (FluidStack) ingredient;
-                else
+            public void accept(@NotNull Object ingredient) {
+                FluidStack ingredientStack = null;
+                if (ingredient instanceof BookmarkItem bookmark)
+                    if (bookmark.ingredient instanceof FluidStack stack) {
+                        ingredientStack = stack.copy();
+                        if(bookmark.getDisplayAmount() != 0)
+                            ingredientStack.amount = clampLong(bookmark.getDisplayAmount());
+                    } else if (bookmark.ingredient instanceof ItemStack is) {
+                        ItemStack temp = is.copy();
+                        temp.setCount(clampLong(bookmark.getDisplayAmount()));
+                        ingredient = temp;
+                    }
+
+                if (ingredientStack == null)
                     ingredientStack = drainFrom(ingredient);
 
                 if (ingredientStack != null) {

--- a/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
@@ -4,11 +4,13 @@ import com.google.common.collect.Lists;
 import gregtech.api.gui.igredient.IGhostIngredientTarget;
 import gregtech.api.util.SlotUtil;
 import mezz.jei.api.gui.IGhostIngredientHandler.Target;
+import mezz.jei.bookmarks.BookmarkItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.items.IItemHandlerModifiable;
+import org.jetbrains.annotations.NotNull;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
@@ -36,23 +38,31 @@ public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTar
 
     @Override
     public List<Target<?>> getPhantomTargets(Object ingredient) {
-        if (!(ingredient instanceof ItemStack)) {
+        if (!(ingredient instanceof ItemStack || ingredient instanceof BookmarkItem))
             return Collections.emptyList();
-        }
+
         Rectangle rectangle = toRectangleBox();
-        return Lists.newArrayList(new Target<Object>() {
+        return Lists.newArrayList(new Target<>() {
             @Override
+            @NotNull
             public Rectangle getArea() {
                 return rectangle;
             }
 
             @Override
-            public void accept(Object ingredient) {
-                if (ingredient instanceof ItemStack) {
+            public void accept(@NotNull Object ingredient) {
+                if (ingredient instanceof BookmarkItem bookmark) {
+                    if (bookmark.ingredient instanceof ItemStack stack) {
+                        ItemStack temp = stack.copy();
+                        temp.setCount(clampLong(bookmark.getDisplayAmount()));
+                        ingredient = temp;
+                    }
+                }
+                if (ingredient instanceof ItemStack stack) {
                     int mouseButton = Mouse.getEventButton();
                     boolean shiftDown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
                     writeClientAction(1, buffer -> {
-                        buffer.writeItemStack((ItemStack) ingredient);
+                        buffer.writeItemStack(stack);
                         buffer.writeVarInt(mouseButton);
                         buffer.writeBoolean(shiftDown);
                     });

--- a/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomSlotWidget.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Lists;
 import gregtech.api.gui.igredient.IGhostIngredientTarget;
 import gregtech.api.util.SlotUtil;
 import mezz.jei.api.gui.IGhostIngredientHandler.Target;
-import mezz.jei.bookmarks.BookmarkItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.ClickType;
 import net.minecraft.item.ItemStack;
@@ -18,6 +17,8 @@ import java.awt.*;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+
+import static gregtech.api.gui.widgets.Bookmark.*;
 
 public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTarget {
 
@@ -36,9 +37,14 @@ public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTar
         return false;
     }
 
+    // Usable if target is an item or item bookmark
+    protected boolean isUsable(Object ingredient) {
+        return ingredient instanceof ItemStack || isItemBookmark(ingredient);
+    }
+
     @Override
     public List<Target<?>> getPhantomTargets(Object ingredient) {
-        if (!(ingredient instanceof ItemStack || ingredient instanceof BookmarkItem))
+        if (!isUsable(ingredient))
             return Collections.emptyList();
 
         Rectangle rectangle = toRectangleBox();
@@ -51,22 +57,24 @@ public class PhantomSlotWidget extends SlotWidget implements IGhostIngredientTar
 
             @Override
             public void accept(@NotNull Object ingredient) {
-                if (ingredient instanceof BookmarkItem bookmark) {
-                    if (bookmark.ingredient instanceof ItemStack stack) {
-                        ItemStack temp = stack.copy();
-                        temp.setCount(clampLong(bookmark.getDisplayAmount()));
-                        ingredient = temp;
-                    }
-                }
-                if (ingredient instanceof ItemStack stack) {
-                    int mouseButton = Mouse.getEventButton();
-                    boolean shiftDown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
-                    writeClientAction(1, buffer -> {
-                        buffer.writeItemStack(stack);
-                        buffer.writeVarInt(mouseButton);
-                        buffer.writeBoolean(shiftDown);
-                    });
-                }
+                if (ingredient instanceof ItemStack stack)
+                    finish(stack);
+                else
+                    ifIsItemBookmark(ingredient, bookmark -> bookmark.ifHasItem(stack -> {
+                        ItemStack copy = stack.copy();
+                        copy.setCount(clampLong(bookmark.getDisplayAmount()));
+                        finish(copy);
+                    }));
+            }
+
+            private void finish(ItemStack stack) {
+                int mouseButton = Mouse.getEventButton();
+                boolean shiftDown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
+                writeClientAction(1, buffer -> {
+                    buffer.writeItemStack(stack);
+                    buffer.writeVarInt(mouseButton);
+                    buffer.writeBoolean(shiftDown);
+                });
             }
         });
     }


### PR DESCRIPTION
Unlike JEI, HEI supports click-and-drag targets from its Bookmarks pane. However, it uses a special wrapper class `BookmarkItem` which was not a recognized type by Phantom widgets.

Because this class only exists in HEI, referencing it directly would result in crashes if someone used JEI instead. To circumvent this, I created a wrapper type that encapsulates the reflection necessary to conditionally load this class at runtime.

The phantom widgets have been reworked to support `BookmarkItem` elements, enabling the use of bookmarked items and fluids/fluid-filled containers where appropriate. This includes transferring the display sizes from e.g. bookmarked recipes.