### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,12 @@ jobs:
             notifications
             wrapper
 
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          path: |
+            build/libs/*.jar
+
   publish_github:
     name: Publish (GitHub)
     needs: build
@@ -50,6 +56,11 @@ jobs:
       contents: write # needed to create GitHub releases
 
     steps:
+      - name: Download Artifacts
+        uses: actions/download-artifacts@v8
+        with:
+          path: build/libs
+
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v3
         with:
@@ -63,6 +74,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Download Artifacts
+        uses: actions/download-artifacts@v8
+        with:
+          path: build/libs
       - name: Publish to Curseforge
         uses: Kira-NT/mc-publish@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
             jdks
             notifications
             wrapper
+
       - name: Publish to GitHub
         uses: softprops/action-gh-release@v1
         with:
@@ -51,16 +52,14 @@ jobs:
           fail_on_unmatched_files: true
 
       - name: Publish to Curseforge
-        uses: gradle/gradle-build-action@v2
-        env:
-          CURSEFORGE_API_KEY: "${{secrets.CURSEFORGE_API_KEY}}"
-          CURSEFORGE_PROJECT_ID: "${{secrets.CURSEFORGE_PROJECT_ID}}"
-          CHANGELOG_LOCATION: "${{env.CHANGELOG_LOCATION}}"
+        uses: Kira-NT/mc-publish@v3
         with:
-          arguments: 'curseforge --daemon'
-          generate-job-summary: false
-          gradle-home-cache-includes: |
-            caches
-            jdks
-            notifications
-            wrapper
+          curseforge-id: ${{ secrets.CURSEFORGE_PROJECT_ID }}
+          curseforge-token: ${{ secrets.CURSEFORGE_API_KEY }}
+          changelog: ${{env.CHANGELOG_LOCATION}}
+          loaders: |
+            forge
+          game-versions: |
+            [1.12,1.13)
+          environment: client | server
+          version-type: release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,15 +11,11 @@ env:
   CHANGELOG_LOCATION: "Changelog is available [here](https://github.com/${{github.repository}}/releases/tag/${{github.ref_name}})"
 
 jobs:
-  Publish:
+  build:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write # needed to create GitHub releases
-
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Check for Duplicate Tags
         run: |
@@ -27,30 +23,46 @@ jobs:
             echo "Tag already exists. A version bump is required."
             exit 1
           fi
+
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
 
-      - name: Build Project
-        uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
           arguments: 'build --build-cache --daemon' # use the daemon here so the rest of the process is faster
-          generate-job-summary: false
+          add-job-summary: 'never'
           gradle-home-cache-includes: |
             caches
             jdks
             notifications
             wrapper
 
+  publish_github:
+    name: Publish (GitHub)
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # needed to create GitHub releases
+
+    steps:
       - name: Publish to GitHub
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: "build/libs/*.jar"
           generate_release_notes: true
           fail_on_unmatched_files: true
 
+  publish_curseforge:
+    name: Publish (CurseForge)
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Publish to Curseforge
         uses: Kira-NT/mc-publish@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -1324,7 +1324,7 @@ def addModrinthDep(String scope, String type, String name) {
     project.modrinth.dependencies.add(dep)
 }
 
-if (customMavenPublishUrl) {
+/* Maven Publishing */ {
     String publishedVersion = modVersion
 
     publishing {
@@ -1345,12 +1345,18 @@ if (customMavenPublishUrl) {
         }
 
         repositories {
-            maven {
-                url = customMavenPublishUrl
-                allowInsecureProtocol = !customMavenPublishUrl.startsWith('https')
-                credentials {
-                    username = providers.environmentVariable('MAVEN_USER').getOrElse('NONE')
-                    password = providers.environmentVariable('MAVEN_PASSWORD').getOrElse('NONE')
+            if(customMavenPublishUrl) {
+                maven {
+                    url = customMavenPublishUrl
+                    allowInsecureProtocol = !customMavenPublishUrl.startsWith('https')
+                    credentials {
+                        username = providers.environmentVariable('MAVEN_USER').getOrElse('NONE')
+                        password = providers.environmentVariable('MAVEN_PASSWORD').getOrElse('NONE')
+                    }
+                }
+            } else {
+                maven {
+                    mavenLocal()
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1723428048
+//version: 1777224609
 /*
  * DO NOT CHANGE THIS FILE!
  * Also, you may replace this file at any time if there is an update available.
@@ -50,6 +50,8 @@ def out = services.get(StyledTextOutputFactory).create('an-output')
 
 
 // Project properties
+loadProjectProperties()
+
 
 // Required properties: we don't know how to handle these being missing gracefully
 checkPropertyExists("modName")
@@ -80,6 +82,7 @@ propertyDefaultIfUnset("includeWellKnownRepositories", true)
 propertyDefaultIfUnset("includeCommonDevEnvMods", true)
 propertyDefaultIfUnset("stripForgeRequirements", false)
 propertyDefaultIfUnset("noPublishedSources", false)
+propertyDefaultIfUnset("mixinProviderSpec", "zone.rong:mixinbooter:10.6")
 propertyDefaultIfUnset("forceEnableMixins", false)
 propertyDefaultIfUnset("mixinConfigRefmap", "mixins.${project.modId}.refmap.json")
 propertyDefaultIfUnsetWithEnvVar("enableCoreModDebug", false, "CORE_MOD_DEBUG")
@@ -315,14 +318,6 @@ tasks.withType(ScalaCompile).configureEach {
 }
 
 
-// Allow others using this buildscript to have custom gradle code run
-if (getFile('addon.gradle').exists()) {
-    apply from: 'addon.gradle'
-} else if (getFile('addon.gradle.kts').exists()) {
-    apply from: 'addon.gradle.kts'
-}
-
-
 // Configure Minecraft
 
 // Try to gather mod version from git tags if version is not manually specified
@@ -369,11 +364,14 @@ minecraft {
 
     // JVM arguments
     extraRunJvmArguments.add("-ea:${modGroup}")
+
+    // enable JLine Terminal since idea_rt.jar is no longer added to the classpath
+    extraRunJvmArguments.add('-Dterminal.jline=true')
     if (usesMixins.toBoolean()) {
         extraRunJvmArguments.addAll([
-            '-Dmixin.hotSwap=true',
-            '-Dmixin.checks.interfaces=true',
-            '-Dmixin.debug.export=true'
+                '-Dmixin.hotSwap=true',
+                '-Dmixin.checks.interfaces=true',
+                '-Dmixin.debug.export=true'
         ])
     }
 
@@ -518,7 +516,6 @@ configurations {
     testRuntimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
 }
 
-String mixinProviderSpec = 'zone.rong:mixinbooter:9.1'
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
@@ -870,10 +867,10 @@ if (enableJava17RunTasks.toBoolean()) {
 
     dependencies {
         if (modId != 'lwjgl3ify') {
-            java17Dependencies("io.github.twilightflower:lwjgl3ify:1.0.0")
-        }
-        java17PatchDependencies("io.github.twilightflower:lwjgl3ify:1.0.0:forgePatches") {
-            transitive = false
+            java17Dependencies("io.github.twilightflower:lwjgl3ify:1.0.1")
+            java17PatchDependencies("io.github.twilightflower:lwjgl3ify:1.0.1:forgePatches") {
+                transitive = false
+            }
         }
     }
 
@@ -1489,6 +1486,20 @@ tasks.register('faq') {
 
 
 // Helpers
+def loadProjectProperties() {
+    def configFile = file("gradle.properties")
+    if (configFile.exists()) {
+        configFile.withReader {
+            def prop = new Properties()
+            prop.load(it)
+            new ConfigSlurper().parse(prop).forEach { String k, def v ->
+                project.ext.setProperty(k, v)
+            }
+        }
+    } else {
+        print("Failed to read from gradle.properties, as it did not exist!")
+    }
+}
 
 def getDefaultArtifactGroup() {
     def lastIndex = project.modGroup.lastIndexOf('.')
@@ -1501,7 +1512,7 @@ def getFile(String relativePath) {
 
 def checkPropertyExists(String propertyName) {
     if (!project.hasProperty(propertyName)) {
-        throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GregTechCEu/Buildscripts/blob/main/gradle.properties")
+        throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"buildscript.properties\" or \"gradle.properties\". You can find all properties and their description here: https://github.com/GregTechCEu/Buildscripts/blob/main/buildscript.properties and https://github.com/GregTechCEu/Buildscripts/blob/main/gradle.properties")
     }
 }
 
@@ -1538,4 +1549,12 @@ def getLastTag() {
     def githubTag = providers.environmentVariable('GITHUB_TAG')
     return runShell('git describe --abbrev=0 --tags ' +
             (githubTag.isPresent() ? runShell('git rev-list --tags --skip=1 --max-count=1') : ''))
+}
+
+
+// Allow others using this buildscript to have custom gradle code run
+if (getFile('addon.gradle').exists()) {
+    apply from: 'addon.gradle'
+} else if (getFile('addon.gradle.kts').exists()) {
+    apply from: 'addon.gradle.kts'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -624,12 +624,12 @@ test {
     }.get()
 
     testLogging {
-        events TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.FAILED
+        events TestLogEvent.SKIPPED, TestLogEvent.PASSED, TestLogEvent.FAILED
         exceptionFormat TestExceptionFormat.FULL
         showExceptions true
         showStackTraces true
         showCauses true
-        showStandardStreams true
+        showStandardStreams false
     }
 
     if (enableJUnit.toBoolean()) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.diffplug.blowdryerSetup' version '1.7.0'
+    id 'com.diffplug.blowdryerSetup' version '1.7.1'
     // Automatic toolchain provisioning
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
 }


### PR DESCRIPTION
CurseForge now requires extra parameters and unhelpfully returns a generic HTTP 500 error from the API when attempting to publish without every little thing it wants.

DarkHax's `curseforgegradle` plugin seemingly doesn't properly handle this unless updated to a version which also has a strict dependency on Java 25, which forces a dependency on Gradle 9.1+. Even without switching to Java 25, even updating to gradle 9.0 (let alone 9.1+) breaks a bunch of the other plugins in the build script.

Following a suggestion from a fellow mod dev, I am looking into [mc-publish](https://github.com/Kira-NT/mc-publish) as an alternative mechanism for publishing artifacts to CurseForge, at least temporarily.